### PR TITLE
Fix incorrect selector for WooCommerce login nonce element

### DIFF
--- a/assets/bh-wp-autologin-urls-woocommerce-login.js
+++ b/assets/bh-wp-autologin-urls-woocommerce-login.js
@@ -4,7 +4,7 @@
 	$(function() {
 
 		var input = $('<button type="button" class="woocommerce button woocommerce-button button woocommerce-form-login__send_magic_link " name="send-magic-link" id="autologin-magic-link" value="Send Magic Link">Email Magic Link</button>');
-		input.insertBefore($('#woocommerce-login-nonce'));
+		input.insertBefore($('input[name="woocommerce-login-nonce"]'));
 
 		var usernameInput = $('#username');
 		var magicLinkButton = $('#autologin-magic-link');


### PR DESCRIPTION
## Problem

The JavaScript attempts to insert the magic link button before `#woocommerce-login-nonce`, but WooCommerce does not render an element with this ID. The nonce is typically stored in a hidden input field with `name="woocommerce-login-nonce"` but no ID attribute, or the element may not exist at all. This causes the button insertion to fail silently.

## Solution

Changed the selector from an ID selector (`#woocommerce-login-nonce`) to a name attribute selector (`input[name="woocommerce-login-nonce"]`) to correctly target the hidden input field that WooCommerce uses for the nonce.

## Changes

- **File**: `assets/bh-wp-autologin-urls-woocommerce-login.js`
- **Line**: 6
- **Before**: `input.insertBefore($('#woocommerce-login-nonce'));`
- **After**: `input.insertBefore($('input[name="woocommerce-login-nonce"]'));`

## Testing

The magic link button should now correctly appear before the nonce input field on the WooCommerce login page.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.