### PR TITLE
Catch exceptions at the plugin's boundaries so it can never fatal a site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Fix: REST API `expires_in` schema – `int` is not a valid type (WordPress `_doing_it_wrong` since 5.5), and it was wrongly marked `format: url`
 * Fix: PHP 8.1 deprecations – `FILTER_SANITIZE_STRING` / `FILTER_SANITIZE_STRIPPED`
 * Fix: PHP 8.4 deprecation – implicit nullable parameter
+* Fix: a failure storing an autologin code no longer breaks the operation it was hooked into – notably `wp_mail()`, where an uncaught exception could break other plugins' emails
+* Fix: catch throwables at every hook the plugin registers, so it can never fatal a site; failures are logged and shown as an admin notice
+* Fix: `$wpdb` error messages were lost before the exception was created, so the error admin notice had no detail
+* Fix: don't email a magic "Sign-in Link" when no autologin code could be created
 * Add: `get_wp_user()` to `API_Interface`
 * Tested up to WordPress 7.0
 * Dev: dev environment modernized – wp-browser 4 / Codeception 5, PHPStan level 8 over `src` and `tests`, PHPCS clean, Rector, Playwright against WordPress 7.0, rebuilt GitHub Actions

--- a/README.txt
+++ b/README.txt
@@ -52,6 +52,10 @@ An API is available for developers to use autologin codes elsewhere in WordPress
 * Fix: REST API `expires_in` schema – `int` is not a valid type (WordPress `_doing_it_wrong` since 5.5), and it was wrongly marked `format: url`
 * Fix: PHP 8.1 deprecations – `FILTER_SANITIZE_STRING` / `FILTER_SANITIZE_STRIPPED`
 * Fix: PHP 8.4 deprecation – implicit nullable parameter
+* Fix: a failure storing an autologin code no longer breaks the operation it was hooked into – notably `wp_mail()`, where an uncaught exception could break other plugins' emails
+* Fix: catch throwables at every hook the plugin registers, so it can never fatal a site; failures are logged and shown as an admin notice
+* Fix: `$wpdb` error messages were lost before the exception was created, so the error admin notice had no detail
+* Fix: don't email a magic "Sign-in Link" when no autologin code could be created
 * Add: `get_wp_user()` to `API_Interface`
 * Tested up to WordPress 7.0
 * Dev: dev environment modernized – wp-browser 4 / Codeception 5, PHPStan level 8 over `src` and `tests`, PHPCS clean, Rector, Playwright against WordPress 7.0, rebuilt GitHub Actions

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,6 @@ parameters:
     paths:
         - src
         - bh-wp-autologin-urls.php
-        - autoload.php
         - functions.php
         - uninstall.php
         - tests
@@ -13,7 +12,6 @@ parameters:
         - tests/_support/_generated
     bootstrapFiles:
         - phpstanbootstrap.php
-        - autoload.php
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
         - vendor/wp-cli/wp-cli/php/class-wp-cli-command.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php

--- a/src/admin/class-users-list-table.php
+++ b/src/admin/class-users-list-table.php
@@ -9,12 +9,17 @@ namespace BrianHenryIE\WP_Autologin_URLs\Admin;
 
 use BrianHenryIE\WP_Autologin_URLs\API_Interface;
 use BrianHenryIE\WP_Autologin_URLs\Settings_Interface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use WP_User;
 
 /**
  * Hooks into WP_User_List_Table to add the link; handles sending the link on the page load.
  */
 class Users_List_Table {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * The plugin settings.
@@ -31,8 +36,11 @@ class Users_List_Table {
 	 *
 	 * @param API_Interface      $api For sending the magic link email.
 	 * @param Settings_Interface $settings The check is the setting enabled.
+	 * @param ?LoggerInterface   $logger A PSR logger.
 	 */
-	public function __construct( API_Interface $api, Settings_Interface $settings ) {
+	public function __construct( API_Interface $api, Settings_Interface $settings, ?LoggerInterface $logger = null ) {
+		$this->setLogger( $logger ?? new NullLogger() );
+
 		$this->api      = $api;
 		$this->settings = $settings;
 	}
@@ -103,7 +111,26 @@ class Users_List_Table {
 			return;
 		}
 
-		$result = $this->api->send_magic_link( $user->user_email );
+		try {
+			$result = $this->api->send_magic_link( $user->user_email );
+		} catch ( \Throwable $e ) {
+			// `admin_init`: a throwable here would white-screen the users list table.
+			$this->logger->error(
+				'Failed sending the magic login email: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'user_id'   => $user->ID,
+				)
+			);
+
+			$result = array(
+				'username_or_email_address' => $user->user_email,
+				'expires_in'                => 0,
+				'expires_in_friendly'       => '',
+				'success'                   => false,
+				'error'                     => true,
+			);
+		}
 
 		add_action(
 			'admin_notices',

--- a/src/api/class-api.php
+++ b/src/api/class-api.php
@@ -180,7 +180,22 @@ class API implements API_Interface {
 
 		// Although this method could return null, the checks to prevent that have already
 		// taken place in this method.
-		$autologin_code = $this->generate_code( $user, $expires_in );
+		try {
+			$autologin_code = $this->generate_code( $user, $expires_in );
+		} catch ( \Throwable $e ) {
+			// Storing the code failed, e.g. the database is unavailable. This plugin is never
+			// essential, so return the URL unchanged rather than breaking whatever was using it.
+			$this->logger->error(
+				'Failed to generate an autologin code: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'user_id'   => $user->ID,
+					'url'       => $url,
+				)
+			);
+
+			return $url;
+		}
 
 		/**
 		 * The typical `wp-login.php` can be configured to be a different URL.
@@ -295,7 +310,21 @@ class API implements API_Interface {
 		 */
 		$delete = apply_filters( 'bh_wp_autologin_urls_should_delete_code_after_use', true, $user_id );
 
-		$saved_details = $this->data_store->get_value_for_code( $password, $delete );
+		try {
+			$saved_details = $this->data_store->get_value_for_code( $password, $delete );
+		} catch ( \Throwable $e ) {
+			// Reading the code failed, e.g. the database is unavailable. Fail closed: an error
+			// here must never log anyone in.
+			$this->logger->error(
+				'Failed to read the stored autologin code: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'user_id'   => $user_id,
+				)
+			);
+
+			return false;
+		}
 
 		if ( null === $saved_details ) {
 			return false;
@@ -316,7 +345,21 @@ class API implements API_Interface {
 	 */
 	public function delete_expired_codes( ?DateTimeInterface $before = null ): array {
 		$before ??= new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return $this->data_store->delete_expired_codes( $before );
+
+		try {
+			return $this->data_store->delete_expired_codes( $before );
+		} catch ( \Throwable $e ) {
+			// Purging is housekeeping; a failure must not stop the cron job which called it.
+			$this->logger->error(
+				'Failed to delete expired autologin codes: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'before'    => $before->format( 'Y-m-d H:i:s' ),
+				)
+			);
+
+			return array( 'deleted_count' => null );
+		}
 	}
 
 	/**
@@ -506,6 +549,21 @@ class API implements API_Interface {
 
 		$autologin_url = $this->add_autologin_to_url( $url, $wp_user, $expires_in );
 
+		if ( $autologin_url === $url ) {
+			// The code could not be generated – `add_autologin_to_url()` logged why – so the link
+			// would not log anyone in. Better to report a failure than to email a sign-in link
+			// which does not sign the user in.
+			$result['success'] = false;
+			$result['error']   = true;
+
+			$this->logger->error(
+				"Not sending a magic link to wp_user:{$wp_user->ID}: no autologin code could be added to the URL.",
+				array( 'result' => $result )
+			);
+
+			return $result;
+		}
+
 		// Add a marker for later logging use of the email.
 		$autologin_url = add_query_arg( array( 'magic' => 'true' ), $autologin_url );
 
@@ -536,7 +594,26 @@ class API implements API_Interface {
 
 		ob_start();
 
-		include $template_email_magic_link;
+		try {
+			include $template_email_magic_link;
+		} catch ( \Throwable $e ) {
+			// A theme override of the template could throw. Close the buffer before returning,
+			// otherwise everything printed after this point is swallowed.
+			ob_end_clean();
+
+			$result['success'] = false;
+			$result['error']   = true;
+
+			$this->logger->error(
+				'Failed rendering the magic link email template: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'template'  => $template_email_magic_link,
+				)
+			);
+
+			return $result;
+		}
 
 		// NB: Do not log the message because it contains a password!
 		$message = ob_get_clean();

--- a/src/api/data-stores/class-db-data-store.php
+++ b/src/api/data-stores/class-db-data-store.php
@@ -82,11 +82,26 @@ class DB_Data_Store implements Data_Store_Interface {
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		$result = dbDelta( $sql );
+
+		// `plugins_loaded`: a throwable here would prevent every later-loading plugin from
+		// registering its hooks. Leave the version option unchanged so it is retried next request.
+		try {
+			$result = dbDelta( $sql );
+		} catch ( \Throwable $e ) {
+			$this->logger->error(
+				'Failed creating the autologin_urls table: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'table'     => $table_name,
+				)
+			);
+
+			return;
+		}
 
 		update_option( self::$db_version_option_name, self::$db_version );
 
-		$this->logger->info( 'Updated database to version ' . self::$db_version );
+		$this->logger->info( 'Updated database to version ' . self::$db_version, array( 'result' => $result ) );
 	}
 
 	/**
@@ -121,9 +136,12 @@ class DB_Data_Store implements Data_Store_Interface {
 			)
 		);
 
-		if ( ! empty( $wpdb->last_error ) ) {
-			$this->logger->error( $wpdb->last_error );
-			throw new Exception( $wpdb->last_error );
+		// Capture before logging: the logger writes to the database, and the successful query
+		// resets `$wpdb->last_error`, so re-reading it here would give an empty string.
+		$last_error = $wpdb->last_error;
+		if ( ! empty( $last_error ) ) {
+			$this->logger->error( $last_error );
+			throw new Exception( $last_error );
 		}
 
 		if ( false === $result ) {
@@ -174,9 +192,12 @@ class DB_Data_Store implements Data_Store_Interface {
 			$wpdb->prepare( 'SELECT expires_at, userhash FROM ' . $wpdb->prefix . 'autologin_urls WHERE hash = %s', $key )
 		);
 
-		if ( ! empty( $wpdb->last_error ) ) {
-			$this->logger->error( $wpdb->last_error );
-			throw new Exception( $wpdb->last_error );
+		// Capture before logging: the logger writes to the database, and the successful query
+		// resets `$wpdb->last_error`, so re-reading it here would give an empty string.
+		$last_error = $wpdb->last_error;
+		if ( ! empty( $last_error ) ) {
+			$this->logger->error( $last_error );
+			throw new Exception( $last_error );
 		}
 
 		if ( is_null( $result ) ) {
@@ -227,9 +248,12 @@ class DB_Data_Store implements Data_Store_Interface {
 		global $wpdb;
 		$result = $wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'autologin_urls WHERE expires_at < %s', $mysql_formatted_date ) );
 
-		if ( ! empty( $wpdb->last_error ) ) {
-			$this->logger->error( $wpdb->last_error );
-			throw new Exception( $wpdb->last_error );
+		// Capture before logging: the logger writes to the database, and the successful query
+		// resets `$wpdb->last_error`, so re-reading it here would give an empty string.
+		$last_error = $wpdb->last_error;
+		if ( ! empty( $last_error ) ) {
+			$this->logger->error( $last_error );
+			throw new Exception( $last_error );
 		}
 
 		// I think this is the number of entries deleted.

--- a/src/api/interface-data-store-interface.php
+++ b/src/api/interface-data-store-interface.php
@@ -12,6 +12,12 @@ namespace BrianHenryIE\WP_Autologin_URLs\API;
 
 use DateTimeInterface;
 
+/**
+ * Implementations may be backed by a database, so every method can fail at runtime. Callers must
+ * assume these throw and degrade gracefully – this plugin is never essential to a request.
+ *
+ * @see \BrianHenryIE\WP_Autologin_URLs\API\Data_Stores\DB_Data_Store
+ */
 interface Data_Store_Interface {
 
 	/**
@@ -20,6 +26,8 @@ interface Data_Store_Interface {
 	 * @param int    $user_id The user id the code is being saved for.
 	 * @param string $code The autologin code being used in the user's URL.
 	 * @param int    $expires_in Number of seconds the code is valid for.
+	 *
+	 * @throws \Exception When the code cannot be stored.
 	 */
 	public function save( int $user_id, string $code, int $expires_in ): void;
 
@@ -30,6 +38,7 @@ interface Data_Store_Interface {
 	 * @param bool   $delete Indicate should the code be deleted after retrieving it.
 	 *
 	 * @return string|null
+	 * @throws \Exception When the stored value cannot be read.
 	 */
 	public function get_value_for_code( string $code, bool $delete = true ): ?string;
 
@@ -39,6 +48,7 @@ interface Data_Store_Interface {
 	 * @param DateTimeInterface $before The date from which to purge old codes.
 	 *
 	 * @return array{deleted_count:int|null}
+	 * @throws \Exception When the codes cannot be deleted.
 	 */
 	public function delete_expired_codes( DateTimeInterface $before ): array;
 }

--- a/src/class-bh-wp-autologin-urls.php
+++ b/src/class-bh-wp-autologin-urls.php
@@ -167,7 +167,7 @@ class BH_WP_Autologin_URLs {
 		add_action( 'edit_user_profile', array( $user_edit, 'make_password_available_on_user_page' ), 1, 1 );
 		add_action( 'show_user_profile', array( $user_edit, 'make_password_available_on_user_page' ), 1, 1 );
 
-		$users_list_table = new Users_List_Table( $this->api, $this->settings );
+		$users_list_table = new Users_List_Table( $this->api, $this->settings, $this->logger );
 		add_filter( 'user_row_actions', array( $users_list_table, 'add_magic_email_link' ), 10, 2 );
 		add_action( 'admin_init', array( $users_list_table, 'send_magic_email_link' ) );
 	}
@@ -217,7 +217,7 @@ class BH_WP_Autologin_URLs {
 	 */
 	protected function define_wp_mail_hooks(): void {
 
-		$plugin_wp_mail = new WP_Mail( $this->api, $this->settings );
+		$plugin_wp_mail = new WP_Mail( $this->api, $this->settings, $this->logger );
 
 		add_filter( 'wp_mail', array( $plugin_wp_mail, 'add_autologin_links_to_email' ), 3 );
 	}

--- a/src/login/class-login-ajax.php
+++ b/src/login/class-login-ajax.php
@@ -69,7 +69,21 @@ class Login_Ajax {
 			}
 		}
 
-		$result = $this->api->send_magic_link( $username, $url );
+		try {
+			$result = $this->api->send_magic_link( $username, $url );
+		} catch ( \Throwable $e ) {
+			// This is a public (nopriv) endpoint; return a generic error rather than a fatal,
+			// which would render as an unhandled 500 in the login form's JS.
+			$this->logger->error(
+				'Failed sending the magic login email: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array( 'exception' => $e )
+			);
+
+			wp_send_json_error(
+				array( 'message' => __( 'An error occurred when sending the magic login email.', 'bh-wp-autologin-urls' ) ),
+				500
+			);
+		}
 
 		$response = array();
 

--- a/src/wp-includes/class-cron.php
+++ b/src/wp-includes/class-cron.php
@@ -67,6 +67,18 @@ class Cron {
 		$action_name = current_action();
 		$this->logger->debug( 'bh-wp-autologin-urls delete_expired_codes cron jobs started', array( 'action' => $action_name ) );
 
-		$this->api->delete_expired_codes();
+		// A throwable here would abort the remaining callbacks on this cron event, which may
+		// belong to other plugins.
+		try {
+			$this->api->delete_expired_codes();
+		} catch ( \Throwable $e ) {
+			$this->logger->error(
+				'Failed deleting expired autologin codes: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'action'    => $action_name,
+				)
+			);
+		}
 	}
 }

--- a/src/wp-includes/class-login.php
+++ b/src/wp-includes/class-login.php
@@ -84,6 +84,30 @@ class Login {
 	 */
 	public function process( $user_id ) {
 
+		// `determine_current_user` runs on every request, so an uncaught throwable here would take
+		// down the whole site. Nothing this plugin does is worth that.
+		try {
+			return $this->maybe_login( $user_id );
+		} catch ( \Throwable $e ) {
+			$this->logger->error(
+				'Failed processing the autologin request: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array( 'exception' => $e )
+			);
+
+			return $user_id;
+		}
+	}
+
+	/**
+	 * Read the request querystring and log the user in when it contains a valid autologin code.
+	 *
+	 * @see self::process() for the exception handling.
+	 *
+	 * @param int|bool $user_id The already determined user ID, or false if none.
+	 * @return int|bool
+	 */
+	protected function maybe_login( $user_id ) {
+
 		remove_action( 'determine_current_user', array( $this, 'process' ), 30 );
 
 		// If we're logged in already, or there's no querystring to parse, just return.

--- a/src/wp-includes/class-rest-api.php
+++ b/src/wp-includes/class-rest-api.php
@@ -79,13 +79,23 @@ class REST_API extends WP_REST_Controller {
 			$expires_in = absint( $expires_in );
 		}
 
-		$url = $this->api->add_autologin_to_url(
-			$url,
-			$user,
-			$expires_in
-		);
-
-		// Check was the URL modified at all.
+		// NB: `add_autologin_to_url()` returns the URL unchanged when it cannot add a code – the
+		// user does not exist, the URL is not for this site, or storing the code failed. The
+		// response does not currently distinguish those.
+		try {
+			$url = $this->api->add_autologin_to_url(
+				(string) $url,
+				$user,
+				$expires_in
+			);
+		} catch ( \Throwable $e ) {
+			// The API logs the cause.
+			return new \WP_Error(
+				'autologin_code_failed',
+				__( 'Failed to create the autologin code.', 'bh-wp-autologin-urls' ),
+				array( 'status' => WP_Http::INTERNAL_SERVER_ERROR )
+			);
+		}
 
 		return $this->prepare_item_for_response( $url, $request );
 	}

--- a/src/wp-includes/class-wp-mail.php
+++ b/src/wp-includes/class-wp-mail.php
@@ -12,11 +12,16 @@ namespace BrianHenryIE\WP_Autologin_URLs\WP_Includes;
 
 use BrianHenryIE\WP_Autologin_URLs\API_Interface;
 use BrianHenryIE\WP_Autologin_URLs\Settings_Interface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * The wp_mail hooked functionality of the plugin.
  */
 class WP_Mail {
+
+	use LoggerAwareTrait;
 
 	/**
 	 * The class which adds the autologin codes to the emails.
@@ -37,8 +42,11 @@ class WP_Mail {
 	 *
 	 * @param API_Interface      $api          The API class for adding the autologin code to URLs.
 	 * @param Settings_Interface $settings     The settings to be used.
+	 * @param ?LoggerInterface   $logger       A PSR logger.
 	 */
-	public function __construct( API_Interface $api, Settings_Interface $settings ) {
+	public function __construct( API_Interface $api, Settings_Interface $settings, ?LoggerInterface $logger = null ) {
+
+		$this->setLogger( $logger ?? new NullLogger() );
 
 		$this->api      = $api;
 		$this->settings = $settings;
@@ -56,6 +64,34 @@ class WP_Mail {
 	 * @see wp_mail()
 	 */
 	public function add_autologin_links_to_email( array $wp_mail_args ): array {
+
+		// This plugin is never essential. Whatever goes wrong in here, the email must still send:
+		// an uncaught throwable would escape into `wp_mail()` and break unrelated plugins' mail.
+		try {
+			return $this->maybe_add_autologin_links_to_email( $wp_mail_args );
+		} catch ( \Throwable $e ) {
+			$this->logger->error(
+				'Failed adding autologin links to email: ' . ( '' !== $e->getMessage() ? $e->getMessage() : get_class( $e ) ),
+				array(
+					'exception' => $e,
+					'subject'   => $wp_mail_args['subject'],
+				)
+			);
+
+			return $wp_mail_args;
+		}
+	}
+
+	/**
+	 * Add autologin codes to the URLs in an email, as appropriate with the configured settings.
+	 *
+	 * @see self::add_autologin_links_to_email() for the exception handling.
+	 *
+	 * @param array{to:string|array<string>, subject:string, message:string, headers?:string|array<string>, attachments:string|array<string>} $wp_mail_args The arguments passed to wp_mail() (before processing).
+	 *
+	 * @return array{to:string|array<string>, subject:string, message:string, headers?:string|array<string>, attachments:string|array<string>}
+	 */
+	protected function maybe_add_autologin_links_to_email( array $wp_mail_args ): array {
 
 		switch ( true ) {
 			case is_string( $wp_mail_args['to'] ):

--- a/tests/wpunit/class-never-fatal-wpunit-Test.php
+++ b/tests/wpunit/class-never-fatal-wpunit-Test.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * The plugin is never essential to a request: when its data store fails, the operation it was
+ * hooked into must still complete.
+ *
+ * Regression tests for an uncaught `Exception: Operation not allowed when innodb_force_recovery > 0`
+ * which escaped `DB_Data_Store::save()` through the `wp_mail` filter and broke an unrelated
+ * plugin's email.
+ *
+ * @package bh-wp-autologin-urls
+ * @author Brian Henry <BrianHenryIE@gmail.com>
+ */
+
+namespace BrianHenryIE\WP_Autologin_URLs;
+
+use BrianHenryIE\ColorLogger\ColorLogger;
+use BrianHenryIE\WP_Autologin_URLs\API\API;
+use BrianHenryIE\WP_Autologin_URLs\API\Data_Stores\DB_Data_Store;
+use BrianHenryIE\WP_Autologin_URLs\API\Settings;
+use BrianHenryIE\WP_Autologin_URLs\WP_Includes\Login;
+use BrianHenryIE\WP_Autologin_URLs\WP_Includes\WP_Mail;
+
+/**
+ * @see \BrianHenryIE\WP_Autologin_URLs\API\API
+ * @see \BrianHenryIE\WP_Autologin_URLs\WP_Includes\WP_Mail
+ * @see \BrianHenryIE\WP_Autologin_URLs\WP_Includes\Login
+ */
+class Never_Fatal_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WPTestCase {
+
+	/**
+	 * Make every query touching the autologin table throw, simulating an unavailable database.
+	 *
+	 * The `query` filter runs inside `$wpdb`, so the throwable propagates out of
+	 * `$wpdb->insert()` / `$wpdb->get_row()` exactly as a real database failure would.
+	 */
+	protected function make_the_database_fail(): void {
+		add_filter(
+			'query',
+			function ( $query ) {
+				if ( str_contains( $query, 'autologin_urls' ) ) {
+					throw new \Exception( 'Operation not allowed when innodb_force_recovery > 0.' );
+				}
+				return $query;
+			}
+		);
+	}
+
+	protected function get_api( ColorLogger $logger ): API {
+		$data_store = new DB_Data_Store( $logger );
+		$data_store->create_db();
+
+		return new API( new Settings(), $logger, $data_store );
+	}
+
+	/**
+	 * The reported crash: adding a code fails, so the URL is returned unchanged.
+	 *
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\API\API::add_autologin_to_url
+	 */
+	public function test_add_autologin_to_url_returns_the_url_unchanged(): void {
+
+		$logger  = new ColorLogger();
+		$api     = $this->get_api( $logger );
+		$user_id = $this->factory->user->create();
+
+		$this->make_the_database_fail();
+
+		$url = get_site_url() . '/some-page/';
+
+		$result = $api->add_autologin_to_url( $url, $user_id, 3600 );
+
+		$this->assertEquals( $url, $result, 'The URL should be returned unmodified.' );
+		$this->assertStringNotContainsString( 'autologin=', $result );
+		$this->assertTrue( $logger->hasErrorRecords(), 'The failure should be logged at error level, which surfaces the admin notice.' );
+	}
+
+	/**
+	 * The `wp_mail` filter must return its arguments so the email still sends.
+	 *
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\WP_Includes\WP_Mail::add_autologin_links_to_email
+	 */
+	public function test_wp_mail_filter_returns_its_arguments(): void {
+
+		$logger = new ColorLogger();
+		$api    = $this->get_api( $logger );
+
+		$user_id = $this->factory->user->create();
+		$user    = get_user_by( 'id', $user_id );
+
+		$this->make_the_database_fail();
+
+		$sut = new WP_Mail( $api, new Settings(), $logger );
+
+		$wp_mail_args = array(
+			'to'          => $user->user_email,
+			'subject'     => 'Test subject',
+			'message'     => 'Visit ' . get_site_url() . '/some-page/ to continue.',
+			'attachments' => array(),
+		);
+
+		$result = $sut->add_autologin_links_to_email( $wp_mail_args );
+
+		$this->assertEquals( $wp_mail_args['message'], $result['message'], 'The message should be unmodified.' );
+		$this->assertEquals( $wp_mail_args['to'], $result['to'] );
+	}
+
+	/**
+	 * `determine_current_user` runs on every request, so a database failure must not be fatal –
+	 * and must not log anyone in.
+	 *
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\WP_Includes\Login::process
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\API\API::verify_autologin_password
+	 */
+	public function test_login_returns_the_incoming_user_id(): void {
+
+		$logger  = new ColorLogger();
+		$api     = $this->get_api( $logger );
+		$user_id = $this->factory->user->create();
+
+		// Generate a real code before breaking the database, so the querystring is well-formed.
+		$url = $api->add_autologin_to_url( get_site_url(), $user_id, 3600 );
+		$this->assertStringContainsString( 'autologin=', $url, 'Precondition: a code was created.' );
+
+		$this->make_the_database_fail();
+
+		$this->go_to( $url );
+		wp_set_current_user( 0 );
+
+		$sut = new Login( $api, new Settings(), $logger );
+
+		$result = $sut->process( 0 );
+
+		$this->assertEquals( 0, $result, 'A database failure must not log the user in.' );
+	}
+
+	/**
+	 * The cron callback must not throw – other callbacks on the event would not run.
+	 *
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\API\API::delete_expired_codes
+	 */
+	public function test_delete_expired_codes_does_not_throw(): void {
+
+		$logger = new ColorLogger();
+		$api    = $this->get_api( $logger );
+
+		$this->make_the_database_fail();
+
+		$result = $api->delete_expired_codes();
+
+		$this->assertNull( $result['deleted_count'] );
+		$this->assertTrue( $logger->hasErrorRecords() );
+	}
+
+	/**
+	 * Rather than emailing a "Sign-in Link" which does not sign anyone in.
+	 *
+	 * @covers \BrianHenryIE\WP_Autologin_URLs\API\API::send_magic_link
+	 */
+	public function test_magic_link_is_not_sent_without_a_code(): void {
+
+		$logger  = new ColorLogger();
+		$api     = $this->get_api( $logger );
+		$user_id = $this->factory->user->create();
+		$user    = get_user_by( 'id', $user_id );
+
+		$this->make_the_database_fail();
+
+		$mail_sent = false;
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit ) use ( &$mail_sent ) {
+				$mail_sent = true;
+				return true;
+			}
+		);
+
+		$result = $api->send_magic_link( $user->user_email );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertTrue( $result['error'] ?? false );
+		$this->assertFalse( $mail_sent, 'No email should be sent when the link would not work.' );
+	}
+}

--- a/tests/wpunit/wp-includes/class-login-wpunit-Test.php
+++ b/tests/wpunit/wp-includes/class-login-wpunit-Test.php
@@ -182,19 +182,19 @@ class Login_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WPTestCase {
 
 		$sut = new Login( $api, $settings, $logger, $user_finder_factory );
 
-		$exception = null;
+		$redirected_to = null;
 
 		$_SERVER['REQUEST_URI'] = 'http://example.org/wp-login.php?redirect_to=http%3A%2F%2Fexample.org%2Fmy-account%';
 		$_GET['redirect_to']    = rawurlencode( 'http://example.org/my-account' );
 
+		// Record the destination and return false so `wp_redirect()` does not `exit()`.
+		// NB: this cannot throw to capture the location – `Login::process()` catches throwables so
+		// the plugin can never fatal a request.
 		add_filter(
 			'wp_redirect',
-			/**
-			 * @return never
-			 * @throws \Exception Always, to capture the redirect target.
-			 */
-			function ( $location ) {
-				throw new \Exception( $location );
+			function ( $location ) use ( &$redirected_to ) {
+				$redirected_to = $location;
+				return false;
 			}
 		);
 
@@ -205,15 +205,8 @@ class Login_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WPTestCase {
 			}
 		);
 
-		try {
-			$sut->process( false );
-		} catch ( \Exception $e ) {
-			$exception = $e;
-		}
+		$sut->process( false );
 
-		$this->assertNotNull( $exception );
-
-		/** @var \Exception $exception */
-		$this->assertEquals( 'http://example.org/my-account', $exception->getMessage() );
+		$this->assertEquals( 'http://example.org/my-account', $redirected_to );
 	}
 }


### PR DESCRIPTION
Stacked on #30 — base is `modernize-dev-environment`, so the diff here is just the two commits.

## The crash

A site with `innodb_force_recovery > 0` hit an uncaught exception from `DB_Data_Store::save()`:

```
Uncaught Exception: Operation not allowed when innodb_force_recovery > 0.
  in src/api/data-stores/class-db-data-store.php:126
#0 API->generate_password()  #1 API->generate_code()  #2 API->add_autologin_to_url()
#3 API->{closure}()  #4 preg_replace_callback()  #5 API->add_autologin_to_message()
#6 WP_Mail->add_autologin_links_to_email()   ← the `wp_mail` filter
#7 WP_Hook->apply_filters() … wp_mail() … Wordfence alert … wp plugin deactivate
```

Nothing on the path caught it, so it escaped through the `wp_mail` filter and broke **someone else's** email — a Wordfence alert during a WP-CLI plugin deactivation. The same exposure existed on `determine_current_user`, which runs on *every* request.

This plugin is never essential. When it cannot add an autologin code, the correct outcome is a normal email with a normal URL.

## The notice already existed

`bh-wp-logger` turns any `$logger->error()` into a dismissible admin notice with a "View Logs" link, and `DB_Data_Store::save()` was already logging immediately before it threw. So no new notice mechanism was added — the missing piece was purely the `catch`. It is backed by a wp_option (`bh-wp-autologin-urls-recent-error-data`) rather than a transient.

One accepted gap: `Logger::instance()` returns a `NullLogger` when the log level is `none`, so those sites get no notice. Reasonable — they opted out of logging.

## Changes

Catches `\Throwable` rather than `\Exception`: a `TypeError` from a third-party filter is as fatal as a database error.

**Graceful degradation in `API`,** where a sensible fallback exists:

| Method | On failure |
|---|---|
| `add_autologin_to_url()` | returns the URL unchanged — the fix for the reported crash; the email still sends, without a code |
| `verify_autologin_password()` | returns `false` — fail closed, a database error must never log anyone in |
| `delete_expired_codes()` | returns a null count |
| `send_magic_link()` | closes its output buffer if the template throws, and reports failure rather than emailing a "Sign-in Link" which would not sign anyone in |

**Backstops at the hook seams,** each returning its input unchanged: `wp_mail`, `determine_current_user`, the cron callback, the REST create-item route, the nopriv AJAX handler, the users-list-table `admin_init` handler, and `create_db()` on `plugins_loaded`.

`Data_Store_Interface` now declares `@throws` on all three methods — only the implementation did, so callers coding against the interface had no signal.

## Two bugs found while verifying

**Every one of these exceptions carried an empty message.** `DB_Data_Store` read `$wpdb->last_error` twice — once for the guard, again to build the exception — and the `$this->logger->error()` call between them writes to the database; that successful query resets `last_error`. The admin notice would have read `Error: ""`. Fixed at all three throw sites.

**`Login::maybe_redirect()`'s test** captured the redirect target by throwing from a `wp_redirect` filter, which `process()` now catches. It records the location and returns `false` instead — which also stops `wp_redirect()` reaching its `exit()`.

## Verification

`unit` 76, `wpunit` 54, `integration` 26 — all passing. phpcs and phpstan (level 8) clean.

New `tests/wpunit/class-never-fatal-wpunit-Test.php` drives a real failure by making every query touching `autologin_urls` throw, and asserts the five degradation paths.

Reproduced the original failure against wp-env by renaming the table away:

- `wp_mail()` returned a boolean instead of fataling
- the front page stayed `200`
- wp-admin rendered: *"**Autologin URLs.** Error: "Failed to generate an autologin code: Table 'wordpress.wp_autologin_urls' doesn't exist" … View Logs. Dismiss this notice."*

## Notes

- During a database outage, `verify_autologin_password()` failing closed makes `Login` treat the request as a bad code and **record a rate-limit failure** — so ~5 page loads with an autologin URL could lock that IP out for a day. Separating "code invalid" from "could not check" needs a signature change, so it is flagged rather than done.
- `REST_API::create_item()` returns **201 with a codeless URL** when the requested user does not exist (`test_admin_authenticated` relies on this). I briefly changed it to a 500 and backed that out — it is a REST-semantics decision, not an exception-handling one.
- Includes a one-line `phpstan.neon` fix: bbcd4c4 deleted `autoload.php` but left it in `paths` and `bootstrapFiles`, so phpstan aborted and `composer cs` could not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
